### PR TITLE
Fix documentation to use the genesis-file flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ This will start `avalanchego` from the `NodeV1` directory and you should see the
 In another terminal, lets create our subnet (the `ggt utils init` cmd we ran earlier creates a sample genesis with all precompiles enabled):
 
 ```sh
-ggt wallet create-chain NodeV1 MyChain subnetevm subnetevm-genesis.json
+ggt wallet create-chain NodeV1 MyChain subnetevm --genesis-file subnetevm-genesis.json
 ```
 
 This command assumes NodeV1 is running, and will create a new Subnet, and then inside that subnet it will create a blockchain with the name `MyChain`, using the `subnetevm` virtual machine binary we registered earlier, and using the specified genesis file.


### PR DESCRIPTION
fixes #10 by improving the documentation to use the correct commands. 

In #10 the error was occuring because the `create-chain` command expects the subnetID at the 4th parameter, so would throw an error if adding the genesis file instead of using the genesis file flag. 

#### Proof new command works 
![CleanShot 2024-04-12 at 12 23 11@2x](https://github.com/multisig-labs/GoGoTools/assets/15036618/d494b40c-9f0e-46e4-a63f-7976be1b980b)
